### PR TITLE
Fixes #20, remove ucspi-tcp recipe inclusion

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,13 @@ suites:
     attributes:
       djbdns:
         service_type: runit
+  - name: source
+    run_list:
+      - recipe[test]
+    attributes:
+      djbdns:
+        service_type: runit
+        install_method: source
 
   - name: dbndns
     run_list:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,6 @@ when "aur"
 when "source"
 
   include_recipe "build-essential"
-  include_recipe "ucspi-tcp"
 
   bash "install_djbdns" do
     user "root"

--- a/test/fixtures/cookbooks/test/recipes/debian.rb
+++ b/test/fixtures/cookbooks/test/recipes/debian.rb
@@ -1,2 +1,1 @@
 execute 'apt-get update' if platform_family?('debian')
-

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -9,4 +9,4 @@ file '/etc/resolv.conf' do
 end
 
 # for the `host` command used in the tests
-package 'bind-utils' if platform_family?('rhel')
+package 'bind-utils' if platform_family?('rhel', 'fedora')

--- a/test/integration/source/serverspec/default_spec.rb
+++ b/test/integration/source/serverspec/default_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../../../kitchen/data/spec_helper'
+
+describe 'public-dnscache' do
+  describe port(53) do
+    it { should be_listening.with('udp') }
+  end
+
+  describe command('host chef.io') do
+    its(:stdout) { should match(/chef.io has address.*/) }
+  end
+end
+
+describe 'tinydns' do
+  describe port(53) do
+    it { should be_listening.on('127.0.0.1').with('udp') }
+  end
+
+  describe file('/etc/service/tinydns/root/data') do
+    its(:content) { should match(/.vagrantup.com:127.0.0.1:a:259200/) }
+  end
+
+  describe file('/etc/service/tinydns/root/data.cdb') do
+    it { should be_file }
+  end
+end


### PR DESCRIPTION
The ucspi-tcp recipe is not needed for a source installation. Added a source suite with tests (copied directly from the other suite).