### PR TITLE
Avoid 1.7.X runit release that breaks djbdns installs

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ recipe            'djbdns::server', 'Sets up external TinyDNS'
   depends cb
 end
 
-depends 'runit', '~> 1.6'
+depends 'runit', '~> 1.6.0'
 
 %w{ ubuntu debian redhat centos scientific amazon oracle arch }.each do |os|
   supports os


### PR DESCRIPTION
See https://github.com/hw-cookbooks/runit/issues/144 for details.  This should really get released ASAP to prevent breaking installs.